### PR TITLE
Improve the StatsD aspect interface

### DIFF
--- a/lib/co_aspects/aspects/stats_increment_aspect.rb
+++ b/lib/co_aspects/aspects/stats_increment_aspect.rb
@@ -11,6 +11,10 @@ module CoAspects
     # added at the end using a block that receives the same arguments as the
     # method.
     #
+    # Note: The default key is used if both `as` and block are missing. If
+    # either is present, the default is not used and if both are present, then
+    # they are simply concatenated.
+    #
     # Examples
     #
     #   module MyModule

--- a/lib/co_aspects/aspects/stats_measure_aspect.rb
+++ b/lib/co_aspects/aspects/stats_measure_aspect.rb
@@ -12,6 +12,10 @@ module CoAspects
     # added at the end using a block that receives the same arguments as the
     # method.
     #
+    # Note: The default key is used if both `as` and block are missing. If
+    # either is present, the default is not used and if both are present, then
+    # they are simply concatenated.
+    #
     # Examples
     #
     #   module MyModule

--- a/lib/co_aspects/aspects/statsd_helper.rb
+++ b/lib/co_aspects/aspects/statsd_helper.rb
@@ -8,9 +8,13 @@ module CoAspects
       end
 
       def key(klass, method_name, method_args, statsd_prefix, statsd_block)
-        key = statsd_prefix || default_prefix(klass, method_name)
-        key += ".#{statsd_block.call(*method_args)}" if statsd_block
-        key.downcase
+        if statsd_prefix || statsd_block
+          key = statsd_prefix.to_s
+          key += statsd_block.call(*method_args) if statsd_block
+          key.downcase
+        else
+          default_prefix(klass, method_name)
+        end
       end
     end
   end

--- a/spec/unit/aspects/stats_increment_aspect_spec.rb
+++ b/spec/unit/aspects/stats_increment_aspect_spec.rb
@@ -8,20 +8,40 @@ describe CoAspects::Aspects::StatsIncrementAspect do
       def perform_default_key
         :success
       end
-      _stats_increment(as: 'CUSTOM.KEY') { |arg| arg.to_s }
+      _stats_increment as: 'custom.key'
+      def perform_only_as
+        :success
+      end
+      _stats_increment { |arg| arg.to_s }
+      def perform_only_block(arg)
+        arg
+      end
+      _stats_increment(as: 'CUSTOM.KEY.') { |arg| arg.to_s }
       def perform_dynamic_key(arg)
         arg
       end
     end
   end
 
-  it 'stores the increment on StatsD' do
+  it 'stores the increment with the default key' do
     expect(StatsD).to receive(:increment)
       .with('name.target.perform_default_key')
     Name::Target.new.perform_default_key
   end
 
-  it 'builds a dynamic key if given' do
+  it 'uses only the block if present' do
+    expect(StatsD).to receive(:increment)
+      .with('dynamic.key')
+    Name::Target.new.perform_only_block('dynamic.key')
+  end
+
+  it 'uses only the alias if present' do
+    expect(StatsD).to receive(:increment)
+      .with('custom.key')
+    Name::Target.new.perform_only_as
+  end
+
+  it 'uses both alias and block if both are present' do
     expect(StatsD).to receive(:increment)
       .with('custom.key.dynamic')
     Name::Target.new.perform_dynamic_key('dynamic')


### PR DESCRIPTION
If either alias or block is given, the default key is not used. This is because
when a block is given it's easier to asume that the block will contain the
complete key.

There is no magic between default values, alias values and block values.

Alias and block are concatenated, forcing the user to include a `'.'` at the end
of the alias value making it explicit that they are concatenated.
