### PR TITLE
[SWAT-414] Improve annotation block scope

### DIFF
--- a/lib/co_aspects/aspects/stats_increment_aspect.rb
+++ b/lib/co_aspects/aspects/stats_increment_aspect.rb
@@ -40,7 +40,7 @@ module CoAspects
     #   # => StatsD.increment('my_key.dynamic')
     class StatsIncrementAspect < Aspector::Base
       around interception_arg: true, method_arg: true do |interception, method, proxy, *args, &block|
-        key = StatsdHelper.key(self.class,
+        key = StatsdHelper.key(self,
                                method,
                                args,
                                interception.options[:annotation][:as],

--- a/lib/co_aspects/aspects/stats_measure_aspect.rb
+++ b/lib/co_aspects/aspects/stats_measure_aspect.rb
@@ -41,7 +41,7 @@ module CoAspects
     #   # => StatsD.measure('my_key.dynamic')
     class StatsMeasureAspect < Aspector::Base
       around interception_arg: true, method_arg: true do |interception, method, proxy, *args, &block|
-        key = StatsdHelper.key(self.class,
+        key = StatsdHelper.key(self,
                                method,
                                args,
                                interception.options[:annotation][:as],

--- a/lib/co_aspects/aspects/statsd_helper.rb
+++ b/lib/co_aspects/aspects/statsd_helper.rb
@@ -10,7 +10,9 @@ module CoAspects
       def key(instance, method_name, method_args, statsd_prefix, statsd_block)
         if statsd_prefix || statsd_block
           key = statsd_prefix.to_s
-          key += statsd_block.call(*method_args).to_s if statsd_block
+          if statsd_block
+            key += instance.instance_exec(*method_args, &statsd_block).to_s
+          end
           key.downcase
         else
           default_prefix(instance.class, method_name)

--- a/lib/co_aspects/aspects/statsd_helper.rb
+++ b/lib/co_aspects/aspects/statsd_helper.rb
@@ -7,13 +7,13 @@ module CoAspects
         klass.name.underscore.tr('/', '.') + ".#{method_name}"
       end
 
-      def key(klass, method_name, method_args, statsd_prefix, statsd_block)
+      def key(instance, method_name, method_args, statsd_prefix, statsd_block)
         if statsd_prefix || statsd_block
           key = statsd_prefix.to_s
           key += statsd_block.call(*method_args) if statsd_block
           key.downcase
         else
-          default_prefix(klass, method_name)
+          default_prefix(instance.class, method_name)
         end
       end
     end

--- a/lib/co_aspects/aspects/statsd_helper.rb
+++ b/lib/co_aspects/aspects/statsd_helper.rb
@@ -10,7 +10,7 @@ module CoAspects
       def key(instance, method_name, method_args, statsd_prefix, statsd_block)
         if statsd_prefix || statsd_block
           key = statsd_prefix.to_s
-          key += statsd_block.call(*method_args) if statsd_block
+          key += statsd_block.call(*method_args).to_s if statsd_block
           key.downcase
         else
           default_prefix(instance.class, method_name)

--- a/spec/unit/aspects/stats_increment_aspect_spec.rb
+++ b/spec/unit/aspects/stats_increment_aspect_spec.rb
@@ -4,6 +4,9 @@ describe CoAspects::Aspects::StatsIncrementAspect do
   before do
     stub_class('Name::Target') do
       aspects_annotations!
+      def initialize
+        @var = 'hello.world'
+      end
       _stats_increment
       def perform_default_key
         :success
@@ -15,6 +18,10 @@ describe CoAspects::Aspects::StatsIncrementAspect do
       _stats_increment { |arg| arg.to_s }
       def perform_only_block(arg)
         arg
+      end
+      _stats_increment { @var }
+      def perform_block_scope
+        :success
       end
       _stats_increment(as: 'CUSTOM.KEY.') { |arg| arg.to_s }
       def perform_dynamic_key(arg)
@@ -33,6 +40,12 @@ describe CoAspects::Aspects::StatsIncrementAspect do
     expect(StatsD).to receive(:increment)
       .with('dynamic.key')
     Name::Target.new.perform_only_block('dynamic.key')
+  end
+
+  it 'can access instance variables via the block' do
+    expect(StatsD).to receive(:increment)
+      .with('hello.world')
+    Name::Target.new.perform_block_scope
   end
 
   it 'uses only the alias if present' do


### PR DESCRIPTION
Allow annotation blocks to have access to the annotated class context.
