### PR TITLE
[SWAT-415] Improved newrelic support

### DIFF
--- a/lib/co_aspects/aspects/rescue_and_notify_aspect.rb
+++ b/lib/co_aspects/aspects/rescue_and_notify_aspect.rb
@@ -1,9 +1,16 @@
 require 'newrelic_rpm'
+require_relative 'rescue_and_notify_error'
 
 module CoAspects
   module Aspects
     # Rescues any error and notifies NewRelic about it, without raising it
     # again.
+    #
+    # If the exception responds to `newrelic_opts` then the return value will be
+    # used as the noticed error options.
+    #
+    # Important: The class `CoAspects::Aspects::RescueAndNotifyError` can be
+    # used as parent to custom error classes.
     #
     # Important: If CoAspects::Aspects::RescueAndNotifyAspect.enable_test_mode!
     # is executed, then instead of calling NewRelic, it will raise the exception

--- a/lib/co_aspects/aspects/rescue_and_notify_aspect.rb
+++ b/lib/co_aspects/aspects/rescue_and_notify_aspect.rb
@@ -56,7 +56,7 @@ module CoAspects
           if RescueAndNotifyAspect.test_mode
             raise e
           else
-            NewRelic::Agent.notice_error(e)
+            NewRelic::Agent.notice_error(e, {})
           end
         end
       end

--- a/lib/co_aspects/aspects/rescue_and_notify_aspect.rb
+++ b/lib/co_aspects/aspects/rescue_and_notify_aspect.rb
@@ -56,7 +56,7 @@ module CoAspects
           if RescueAndNotifyAspect.test_mode
             raise e
           else
-            NewRelic::Agent.notice_error(e, stack_trace: e.backtrace)
+            NewRelic::Agent.notice_error(e)
           end
         end
       end

--- a/lib/co_aspects/aspects/rescue_and_notify_aspect.rb
+++ b/lib/co_aspects/aspects/rescue_and_notify_aspect.rb
@@ -56,7 +56,11 @@ module CoAspects
           if RescueAndNotifyAspect.test_mode
             raise e
           else
-            NewRelic::Agent.notice_error(e, {})
+            opts = {}
+            if e.respond_to?(:newrelic_opts)
+              opts.merge!(e.newrelic_opts)
+            end
+            NewRelic::Agent.notice_error(e, opts)
           end
         end
       end

--- a/lib/co_aspects/aspects/rescue_and_notify_error.rb
+++ b/lib/co_aspects/aspects/rescue_and_notify_error.rb
@@ -1,0 +1,12 @@
+module CoAspects
+  module Aspects
+    class RescueAndNotifyError < RuntimeError
+      attr_reader :newrelic_opts
+
+      def initialize(message, newrelic_opts)
+        super(message)
+        @newrelic_opts = newrelic_opts
+      end
+    end
+  end
+end

--- a/spec/unit/aspects/rescue_and_notify_aspect_spec.rb
+++ b/spec/unit/aspects/rescue_and_notify_aspect_spec.rb
@@ -14,6 +14,7 @@ describe CoAspects::Aspects::RescueAndNotifyAspect do
 
   it 'notifies new relic if an error is raised' do
     expect(NewRelic::Agent).to receive(:notice_error)
+      .with(kind_of(Exception), {})
     expect(Target.new.perform(false)).to eq(nil)
   end
 

--- a/spec/unit/aspects/rescue_and_notify_aspect_spec.rb
+++ b/spec/unit/aspects/rescue_and_notify_aspect_spec.rb
@@ -1,13 +1,7 @@
 require 'spec_helper'
 
 describe CoAspects::Aspects::RescueAndNotifyAspect do
-  class FakeError < RuntimeError
-    attr_reader :newrelic_opts
-
-    def initialize(message, newrelic_opts)
-      super(message)
-      @newrelic_opts = newrelic_opts
-    end
+  class FakeError < CoAspects::Aspects::RescueAndNotifyError
   end
 
   before do


### PR DESCRIPTION
Implements a way to pass custom options to `NewRelic::Agent.notice_error` from the exception raised.
